### PR TITLE
CoreOS identification fix

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -134,7 +134,12 @@ get_distro() {
                     "tiny") distro="${NAME:-${DISTRIB_ID:-${TAILS_PRODUCT_NAME}}}" ;;
                     "off") distro="${PRETTY_NAME:-${DISTRIB_DESCRIPTION}} ${UBUNTU_CODENAME}" ;;
                 esac
-
+		
+                # Workaround for CoreOS - CoreOS has a VERSION_ID that is epoch since the project
+		# started and hence will change every upgrade. This breaks the catchall os-release
+		# test.	
+		[[ $NAME == "Container Linux by CoreOS" ]] && distro="$ID"
+		
                 # Workarounds for distros that go against the os-release standard.
                 [[ -z "${distro// }" ]] && distro="$(awk '/BLAG/ {print $1; exit}')" "${files[@]}"
                 [[ -z "${distro// }" ]] && distro="$(awk -F'=' '{print $2; exit}')"  "${files[@]}"
@@ -3202,7 +3207,7 @@ get_distro_colors() {
             ascii_file="cloveros"
         ;;
 
-        "Container Linux by CoreOS"*)
+        "coreos"*)
             set_colors 4 7 1
             ascii_file="coreos"
         ;;


### PR DESCRIPTION
## Description

CoreOS has a VERSION_ID that is epoch since the project started and hence will change every upgrade. This breaks the catchall os-release test / the distro test was broken.

Apologies for not catching this on the first submission.   :\

## Features

## Issues

Situation before this patch:

```
$ distro="${NAME:-${DISTRIB_ID}} ${VERSION_ID:-${DISTRIB_RELEASE}}"; echo $distro
Container Linux by CoreOS 1409.1.0
```

Situation after this patch:

```
$ [[ $NAME == "Container Linux by CoreOS" ]] && distro="$ID"; echo $distro
coreos
```

## TODO
